### PR TITLE
Fixed

### DIFF
--- a/StateMachine/StateMachine.cs
+++ b/StateMachine/StateMachine.cs
@@ -72,7 +72,6 @@ public abstract class StateMachine<T> : IStateMachine<T> where T : Enum
         CurrentState.OnEnter();
         
         OnStateChanged?.Invoke(stateType);
-        Logger.Log($"[StateMachine] Switched state to: {CurrentState.StateType}.");
     }
 
     /// <summary>

--- a/StateMachine/StateMachine.csproj
+++ b/StateMachine/StateMachine.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <AssemblyVersion>1.2.0</AssemblyVersion>
+        <AssemblyVersion>1.2.1</AssemblyVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/StateMachineTests/StateMachineTests.csproj
+++ b/StateMachineTests/StateMachineTests.csproj
@@ -7,7 +7,7 @@
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
-        <AssemblyVersion>1.2.0</AssemblyVersion>
+        <AssemblyVersion>1.2.1</AssemblyVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Removed the log as it provides minimal feedback and when a state is switched on enter, the log will print the same message multiple times, as it's called after on enter.